### PR TITLE
Add run_note to info sent to DD via Notification Policy

### DIFF
--- a/assets/policy.rego
+++ b/assets/policy.rego
@@ -118,6 +118,7 @@ tags(extra_tags) = array.concat([tag | tag := extra_tags[_]; contains(tag, ":")]
 	sprintf("account:%s", [input.account.name]),
 	sprintf("branch:%s", [input.run_updated.run.commit.branch]),
 	sprintf("drift_detection:%s", [input.run_updated.run.drift_detection]),
+	sprintf("run_note:%s", [input.run_updated.note]),
 	sprintf("run_type:%s", [lower(input.run_updated.run.type)]),
 	sprintf("final_state:%s", [lower(run_state)]),
 	sprintf("space:%s", [lower(input.run_updated.stack.space.id)]),


### PR DESCRIPTION
Add run_note to info sent to DD

`input.run_updated.note` contains extra information that is helpful for diagnosing the case of Spacelift run failures. In our specific case this field helps indicate when a Spacelift worker crashes. In that case, `run_updated.note` contains "worker crashed".