### PR TITLE
Add run url to datadog data

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 0.2.1
+module_version: 0.2.2
 
 tests:
   - name: Default test

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Common tags for all metrics are the following:
 - `branch` (string): name of the Git branch the run was triggered from;
 - `drift_detection` (boolean): whether the run was triggered by drift detection;
 - `run_type` (string): type of a run, eg. "tracked", "proposed", etc.;
+- `run_url` (string): link to the run that generated the metric;
 - `final_state` (string): the terminal state of the run, eg. "finished", "failed", etc.;
 - `space` (string): name of the Spacelift space the run belongs to;
 - `stack` (string): name of the Spacelift stack the run belongs to;

--- a/assets/policy.rego
+++ b/assets/policy.rego
@@ -120,7 +120,7 @@ tags(extra_tags) = array.concat([tag | tag := extra_tags[_]; contains(tag, ":")]
 	sprintf("drift_detection:%s", [input.run_updated.run.drift_detection]),
 	sprintf("run_note:%s", [input.run_updated.note]),
 	sprintf("run_type:%s", [lower(input.run_updated.run.type)]),
-    sprintf("run_url:%s", [lower(input.run_updated.urls.run)]),
+	sprintf("run_url:%s", [input.run_updated.urls.run]),
 	sprintf("final_state:%s", [lower(run_state)]),
 	sprintf("space:%s", [lower(input.run_updated.stack.space.id)]),
 	sprintf("stack:%s", [lower(input.run_updated.stack.id)]),

--- a/assets/policy.rego
+++ b/assets/policy.rego
@@ -120,6 +120,7 @@ tags(extra_tags) = array.concat([tag | tag := extra_tags[_]; contains(tag, ":")]
 	sprintf("drift_detection:%s", [input.run_updated.run.drift_detection]),
 	sprintf("run_note:%s", [input.run_updated.note]),
 	sprintf("run_type:%s", [lower(input.run_updated.run.type)]),
+    sprintf("run_url:%s", [lower(input.run_updated.urls.run)]),
 	sprintf("final_state:%s", [lower(run_state)]),
 	sprintf("space:%s", [lower(input.run_updated.stack.space.id)]),
 	sprintf("stack:%s", [lower(input.run_updated.stack.id)]),


### PR DESCRIPTION
From: https://github.com/spacelift-io/terraform-spacelift-datadog/pull/5

> This PR adds input.run_updated.urls.run which has the link to the run that generated the metric. This can be useful for creating datadog alerts for failed runs with a link back to the run itself

@maddocash