### PR TITLE
Add triggered_by to info sent to DD via Notification Policy

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 0.2.2
+module_version: 0.2.3
 
 tests:
   - name: Default test

--- a/assets/policy.rego
+++ b/assets/policy.rego
@@ -124,6 +124,7 @@ tags(extra_tags) = array.concat([tag | tag := extra_tags[_]; contains(tag, ":")]
 	sprintf("final_state:%s", [lower(run_state)]),
 	sprintf("space:%s", [lower(input.run_updated.stack.space.id)]),
 	sprintf("stack:%s", [lower(input.run_updated.stack.id)]),
+	sprintf("triggered_by:%s", [input.run_updated.run.triggered_by]),
     sprintf("worker_pool:%s", [worker_pool]),
 ])
 


### PR DESCRIPTION
Add triggered_by to info sent to DataDog

`input.run_updated.run.triggered_by` contains information about who/what triggered the run. That information is helpful in DataDog for distinguishing between runs started by users, stack dependencies, and CLI usage.