### PR TITLE
fix(policy.rego): Use DataDog format for metrics units

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 0.2.3
+module_version: 0.2.4
 
 tests:
   - name: Default test

--- a/assets/policy.rego
+++ b/assets/policy.rego
@@ -87,7 +87,7 @@ policies(extra_tags) = [metric |
 			"value": 1,
 		}],
 		"tags": array.concat(tags(extra_tags), receipt_tags),
-		"unit": "policy",
+		"unit": "item",
 	}
 ]
 
@@ -110,7 +110,7 @@ state_timings(extra_tags) = [metric |
 			"value": state_timing.duration,
 		}],
 		"tags": array.concat(tags(extra_tags), [sprintf("state:%s", [lower(state_timing.state)])]),
-		"unit": "nanoseconds",
+		"unit": "nanosecond",
 	}
 ] 
 


### PR DESCRIPTION
Using the official names for units from the [documentation](https://docs.datadoghq.com/metrics/units/#unit-list) ensures dashboards and graphs automatically use them.
Otherwise the values will be graphed raw with default prefixes like G for giga and T for tera.