### PR TITLE
feat: Add support to remove tags from metrics being sent to datadog

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 0.2.4
+module_version: 0.2.5
 
 tests:
   - name: Default test

--- a/.spacelift/test/test.tf
+++ b/.spacelift/test/test.tf
@@ -18,5 +18,5 @@ module "datadog-metrics" {
   integration_name = "Datadog metrics, run ${var.spacelift_run_id}"
   space_id         = "public-modules-01GVNH2CJKSKHRSMDPBMQ3WZT9"
   extra_tags       = { "env" : "test" }
-  excluded_tags = [ "run_note", "run_url" ]
+  exclude_tags = [ "run_note", "run_url" ]
 }

--- a/.spacelift/test/test.tf
+++ b/.spacelift/test/test.tf
@@ -18,4 +18,5 @@ module "datadog-metrics" {
   integration_name = "Datadog metrics, run ${var.spacelift_run_id}"
   space_id         = "public-modules-01GVNH2CJKSKHRSMDPBMQ3WZT9"
   extra_tags       = { "env" : "test" }
+  excluded_tags = [ "run_note", "run_url" ]
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ module "spacelift_datadog" {
   dd_site = "datadoghq.com"
   space_id = "root"
   extra_tags = {"env":"prod"}
+  exclude_tags = ["run_note", "run_url"]
 }
 ```
 
@@ -41,6 +42,8 @@ Common tags for all metrics are the following:
 - `space` (string): name of the Spacelift space the run belongs to;
 - `stack` (string): name of the Spacelift stack the run belongs to;
 - `worker_pool` (string): name of the Spacelift worker pool the run was executed on - for the public worker pool this value is always `public`;
+
+You can exclude tags using the `exclude_tags` variable, which allows a user to reduce the number of tags added to the metrics.
 
 ## Release
 

--- a/assets/policy.rego.tpl
+++ b/assets/policy.rego.tpl
@@ -114,7 +114,7 @@ state_timings(extra_tags) = [metric |
 	}
 ] 
 
-tags(extra_tags) = array.concat([tag | tag := extra_tags[_]; contains(tag, ":")], ${basic_tags})
+tags(extra_tags) = array.concat([tag | tag := extra_tags[_]; contains(tag, ":")], ${common_tags})
 
 default worker_pool = "public"
 

--- a/assets/policy.rego.tpl
+++ b/assets/policy.rego.tpl
@@ -114,7 +114,11 @@ state_timings(extra_tags) = [metric |
 	}
 ] 
 
-tags(extra_tags) = array.concat([tag | tag := extra_tags[_]; contains(tag, ":")], ${common_tags})
+tags(extra_tags) = array.concat([tag | tag := extra_tags[_]; contains(tag, ":")], 
+	[%{ for key, value in common_tags }
+		sprintf("${key}:%s", ${value}),%{~ endfor }
+	],
+)
 
 default worker_pool = "public"
 

--- a/assets/policy.rego.tpl
+++ b/assets/policy.rego.tpl
@@ -114,19 +114,7 @@ state_timings(extra_tags) = [metric |
 	}
 ] 
 
-tags(extra_tags) = array.concat([tag | tag := extra_tags[_]; contains(tag, ":")], [
-	sprintf("account:%s", [input.account.name]),
-	sprintf("branch:%s", [input.run_updated.run.commit.branch]),
-	sprintf("drift_detection:%s", [input.run_updated.run.drift_detection]),
-	sprintf("run_note:%s", [input.run_updated.note]),
-	sprintf("run_type:%s", [lower(input.run_updated.run.type)]),
-	sprintf("run_url:%s", [input.run_updated.urls.run]),
-	sprintf("final_state:%s", [lower(run_state)]),
-	sprintf("space:%s", [lower(input.run_updated.stack.space.id)]),
-	sprintf("stack:%s", [lower(input.run_updated.stack.id)]),
-	sprintf("triggered_by:%s", [input.run_updated.run.triggered_by]),
-    sprintf("worker_pool:%s", [worker_pool]),
-])
+tags(extra_tags) = array.concat([tag | tag := extra_tags[_]; contains(tag, ":")], ${basic_tags})
 
 default worker_pool = "public"
 

--- a/policy.tf
+++ b/policy.tf
@@ -1,15 +1,15 @@
 locals {
   common_tags = {
     "account":         "[input.account.name]",
-	  "branch":          "[input.run_updated.run.commit.branch]",
-	  "drift_detection": "[input.run_updated.run.drift_detection]",
-	  "run_note":        "[input.run_updated.note]",
-	  "run_type":        "[lower(input.run_updated.run.type)]",
-	  "run_url":         "[input.run_updated.urls.run]",
-	  "final_state":     "[lower(run_state)]",
-	  "space":           "[lower(input.run_updated.stack.space.id)]",
-	  "stack":           "[lower(input.run_updated.stack.id)]",
-	  "triggered_by":    "[input.run_updated.run.triggered_by]",
+    "branch":          "[input.run_updated.run.commit.branch]",
+    "drift_detection": "[input.run_updated.run.drift_detection]",
+    "run_note":        "[input.run_updated.note]",
+    "run_type":        "[lower(input.run_updated.run.type)]",
+    "run_url":         "[input.run_updated.urls.run]",
+    "final_state":     "[lower(run_state)]",
+    "space":           "[lower(input.run_updated.stack.space.id)]",
+    "stack":           "[lower(input.run_updated.stack.id)]",
+    "triggered_by":    "[input.run_updated.run.triggered_by]",
     "worker_pool":     "[worker_pool]",
   }
 }

--- a/policy.tf
+++ b/policy.tf
@@ -19,7 +19,6 @@ resource "spacelift_policy" "datadog-metrics" {
   type     = "NOTIFICATION"
   space_id = var.space_id
 
-  #body   = file("${path.module}/assets/policy.rego")
   body = templatefile("${path.module}/assets/policy.rego.tpl", {
     common_tags = jsonencode([for k, v in local.common_tags : "${k}:${v}" if !contains(var.exclude_tags, k) ]),
   })

--- a/policy.tf
+++ b/policy.tf
@@ -20,7 +20,7 @@ resource "spacelift_policy" "datadog-metrics" {
   space_id = var.space_id
 
   body = templatefile("${path.module}/assets/policy.rego.tpl", {
-    common_tags = jsonencode([for k, v in local.common_tags : "${k}:${v}" if !contains(var.exclude_tags, k) ]),
+    common_tags = {for k, v in local.common_tags : k => v if !contains(var.exclude_tags, k)},
   })
   labels = ["ddmetrics"]
 }

--- a/policy.tf
+++ b/policy.tf
@@ -1,8 +1,27 @@
+locals {
+  common_tags = {
+    "account":         "[input.account.name]",
+	  "branch":          "[input.run_updated.run.commit.branch]",
+	  "drift_detection": "[input.run_updated.run.drift_detection]",
+	  "run_note":        "[input.run_updated.note]",
+	  "run_type":        "[lower(input.run_updated.run.type)]",
+	  "run_url":         "[input.run_updated.urls.run]",
+	  "final_state":     "[lower(run_state)]",
+	  "space":           "[lower(input.run_updated.stack.space.id)]",
+	  "stack":           "[lower(input.run_updated.stack.id)]",
+	  "triggered_by":    "[input.run_updated.run.triggered_by]",
+    "worker_pool":     "[worker_pool]",
+  }
+}
+
 resource "spacelift_policy" "datadog-metrics" {
   name     = "${var.integration_name} (${var.dd_site})"
   type     = "NOTIFICATION"
   space_id = var.space_id
 
-  body   = file("${path.module}/assets/policy.rego")
+  #body   = file("${path.module}/assets/policy.rego")
+  body = templatefile("${path.module}/assets/policy.rego.tpl", {
+    common_tags = jsonencode([for k, v in local.common_tags : "${k}:${v}" if !contains(var.exclude_tags, k) ]),
+  })
   labels = ["ddmetrics"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -43,7 +43,7 @@ variable "extra_tags" {
 }
 
 variable "exclude_tags" {
-  type = list(string)
+  type = set(string)
   description = "Tags to exclude from the common tags"
   default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -41,3 +41,9 @@ variable "extra_tags" {
   description = "Extra tags to add to the Datadog metrics, must be in key:value format"
   default = {}
 }
+
+variable "exclude_tags" {
+  type = list(string)
+  description = "Tags to exclude from the common tags"
+  default = []
+}


### PR DESCRIPTION
Added variable `exclude_tags` allows a user to reduce the number of tags added to the metrics.

I've changed file`policy.repo` to `policy.repo.tpl` to allow proper tags to be passed. For example, `extra_tags` are passed to webhook as labels; later, we use webhook labels as additional tags. We can't do the same with excluding. 

So, I've created common tags in terraform code and passed by template variable to policy.
