### PR TITLE
feat: support logging

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 0.2.5
+module_version: 1.0.0
 
 tests:
   - name: Default test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Spacelift-Datadog metrics integration
+# Spacelift-Datadog integration
 
-Terraform module providing a notification-based integration between Spacelift and Datadog. This particular integration sends metrics to Datadog whenever a run reaches a terminal state.
+Terraform module providing a notification-based integration between Spacelift and Datadog. This particular integration sends metrics and logs to Datadog whenever a run reaches a terminal state.
 
 ## Usage
 
@@ -10,6 +10,8 @@ module "spacelift_datadog" {
 
   dd_api_key = var.dd_api_key
   dd_site = "datadoghq.com"
+  send_logs = true
+  send_metrics = true
   space_id = "root"
   extra_tags = {"env":"prod"}
   exclude_tags = ["run_note", "run_url"]
@@ -29,6 +31,19 @@ The following metrics are sent:
 - `spacelift.integration.run.resources` (counter) - the resources affected by a run. In addition to [common tags](#common-tags), this metric is also tagged with the change type, eg. `change_type:added`, `change_type:changed`, etc.;
 - `spacelift.integration.run.policies` (counter) - policy evaluations for the run. In addition to [common tags](#common-tags), this metric is also tagged with the policy type (eg. `policy_type:plan`), policy name (eg. `policy_name:AWS IAM compliance`) and policy outcome (eg. `policy_outcome:allow`). If the policy sets any [flags](https://docs.spacelift.io/concepts/policy/#policy-flags), these are also added to the metric as tags. Note that we do not include notification policies in this metric, to avoid a circular dependency.
 
+## Logs
+
+The following logs are sent, after the run reaches a terminal state:
+- Preparing Phase
+- Initilization Phase
+- Planning Phase
+- Applying Phase
+
+The integration will _only_ send logs after it reaches a terminal state (eg. `finished`, `failed`, etc.).
+So if you have a plan waiting for confirmation, it will *not* send those logs until after the apply phase.
+
+The integration will put all the logs under the `spacelift` service and the `spacelift-{stack.id}` hostname.
+
 ## Common tags
 
 Common tags for all metrics are the following:
@@ -45,17 +60,24 @@ Common tags for all metrics are the following:
 
 You can exclude tags using the `exclude_tags` variable, which allows a user to reduce the number of tags added to the metrics.
 
+### Log Tags
+
+Logs are tagged with the above-mentioned tags as well, however they are prefixed with `spacelift.{tag}` (eg. `account` == `spacelift.account`).
+The logs are tagged with the following additional tags:
+- `spacelift.stage` (string): stage of the log, eg. "planning", "applying", etc.;
+- `spacelift.run_id` (string): the ID of the run that generated the log;
+
 ## Release
 
 You need to bump the version in `.spacelift/config.yml` file. 
 ```yaml
-module_version: 0.2.3
+module_version: 1.0.0
 ```
 
 Then, the module will be published in `spacelift.io/spacelift-io/datadog/spacelift`.
 
 You need to create the new tag to bump the version on the Terraform registry side.
 ```
-git tag -a -m 'Description...' v0.2.3
+git tag -a -m 'Description...' v1.0.0
 git push --tag
 ```

--- a/policy.tf
+++ b/policy.tf
@@ -1,26 +1,30 @@
 locals {
   common_tags = {
-    "account":         "[input.account.name]",
-    "branch":          "[input.run_updated.run.commit.branch]",
-    "drift_detection": "[input.run_updated.run.drift_detection]",
-    "run_note":        "[input.run_updated.note]",
-    "run_type":        "[lower(input.run_updated.run.type)]",
-    "run_url":         "[input.run_updated.urls.run]",
-    "final_state":     "[lower(run_state)]",
-    "space":           "[lower(input.run_updated.stack.space.id)]",
-    "stack":           "[lower(input.run_updated.stack.id)]",
-    "triggered_by":    "[input.run_updated.run.triggered_by]",
-    "worker_pool":     "[worker_pool]",
+    "account" : "[input.account.name]",
+    "branch" : "[input.run_updated.run.commit.branch]",
+    "drift_detection" : "[input.run_updated.run.drift_detection]",
+    "run_note" : "[input.run_updated.note]",
+    "run_type" : "[lower(input.run_updated.run.type)]",
+    "run_url" : "[input.run_updated.urls.run]",
+    "final_state" : "[lower(run_state)]",
+    "space" : "[lower(input.run_updated.stack.space.id)]",
+    "stack" : "[lower(input.run_updated.stack.id)]",
+    "triggered_by" : "[input.run_updated.run.triggered_by]",
+    "worker_pool" : "[worker_pool]",
   }
 }
 
 resource "spacelift_policy" "datadog-metrics" {
+  count = var.send_logs || var.send_metrics ? 1 : 0
+
   name     = "${var.integration_name} (${var.dd_site})"
   type     = "NOTIFICATION"
   space_id = var.space_id
 
   body = templatefile("${path.module}/assets/policy.rego.tpl", {
-    common_tags = {for k, v in local.common_tags : k => v if !contains(var.exclude_tags, k)},
+    common_tags  = { for k, v in local.common_tags : k => v if !contains(var.exclude_tags, k) },
+    send_metrics = var.send_metrics,
+    send_logs    = var.send_logs,
   })
-  labels = ["ddmetrics"]
+  labels = ["ddmetrics", "ddlogs"]
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     spacelift = {
-      source = "spacelift-io/spacelift"
+      source  = "spacelift-io/spacelift"
       version = ">= 1.1.4"
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "dd_api_key" {
-    type        = string
-    description = "Datadog API key to use for sending metrics."
-    sensitive   = true
+  type        = string
+  description = "Datadog API key to use for sending metrics."
+  sensitive   = true
 }
 
 variable "dd_site" {
@@ -25,9 +25,21 @@ variable "dd_site" {
 }
 
 variable "integration_name" {
-  type = string
+  type        = string
   description = "Name of the integration to create."
-  default = "Datadog metrics"
+  default     = "Datadog"
+}
+
+variable "send_logs" {
+  type        = bool
+  description = "Whether to send logs to Datadog."
+  default     = true
+}
+
+variable "send_metrics" {
+  type        = bool
+  description = "Whether to send metrics to Datadog."
+  default     = true
 }
 
 variable "space_id" {
@@ -37,13 +49,13 @@ variable "space_id" {
 }
 
 variable "extra_tags" {
-  type = map(string)
+  type        = map(string)
   description = "Extra tags to add to the Datadog metrics, must be in key:value format"
-  default = {}
+  default     = {}
 }
 
 variable "exclude_tags" {
-  type = set(string)
+  type        = set(string)
   description = "Tags to exclude from the common tags"
-  default = []
+  default     = []
 }


### PR DESCRIPTION
Note: I do not have access to a DD account with logging enabled. I can see the webhooks working in spacelift and getting the correct response from datadog but I have no idea what they look like in DD. Im still attempting to get access to an account to see what it actually looks like but this PR should be 90% of the way there.